### PR TITLE
update-deliveroo-configuration.md

### DIFF
--- a/content/apps/deliveroo/en/configuration.md
+++ b/content/apps/deliveroo/en/configuration.md
@@ -7,7 +7,7 @@ meta:
   description: See instructions to configure the Deliveroo Bridge to work seamlessly with Deliveroo and your EPOS or other apps connected to HubRise. Configuration is simple.
 ---
 
-The Configuration page allows you to customise the behaviour of the Deliveroo Bridge based on your preferences.
+The configuration page allows you to customise the behaviour of the Deliveroo Bridge based on your preferences.
 These are divided into different categories for an easier navigation.
 
 ![Deliveroo Bridge configuration page](../images/002-en-configuration-page.png)
@@ -18,14 +18,13 @@ From this section, you can decide which language will be used to encode the orde
 
 ## Default Customer
 
-By default, Deliveroo does not encode the customer's details when they send an order to HubRise.
+By default, Deliveroo does not encode the customer's details when they send an order to HubRise. However, certain EPOS systems require a customer to be specified in every order.
 
-However, certain EPOS systems require a customer to be specified in every order.
 This section allows you to define the default first name, last name and email address that will be used for all your Deliveroo orders.
 
 ## Service Types
 
-Service Type such as Delivery by Deliveroo, Delivery by your own fleed or Collection might require the corresponding ref code entry. Refer to your connected EPOS documentation on the HubRise website to verify.
+Service types such as Delivery by Deliveroo, Delivery by your own fleet or Collection might require the corresponding ref code entry. Refer to your connected EPOS documentation on the HubRise website to verify.
 
 ## Delivery Charges
 
@@ -35,7 +34,7 @@ If delivery charges apply, a ref code might be required. Refer to your connected
 
 Deliveroo customers can pay for their order either online or by cash on delivery.
 
-This section of the Configuration page allows you to specify the ref codes for these two payment methods, together with the payment type associated with online payments on the Deliveroo web site. Cash payments are always associated with the `cash` type.
+This section of the configuration page allows you to specify the ref codes for these two payment methods, together with the payment type associated with online payments on the Deliveroo web site. Cash payments are always associated with the `cash` type.
 
 ## Discounts
 
@@ -47,4 +46,4 @@ Once you are happy with the configuration of the Deliveroo Bridge, click **Save*
 
 ## Resetting the Configuration
 
-You can always restore the Configuration page to its default values and change the Deliveroo location ID associated with your HubRise location by clicking on **Reset the configuration** at the bottom of the page.
+You can always restore the configuration page to its default values and change the Deliveroo location ID associated with your HubRise location by clicking on **Reset the configuration** at the bottom of the page.

--- a/content/apps/deliveroo/en/configuration.md
+++ b/content/apps/deliveroo/en/configuration.md
@@ -20,20 +20,20 @@ From this section, you can decide which language will be used to encode the orde
 
 By default, Deliveroo does not encode the customer's details when they send an order to HubRise.
 
-However, certain POS systems require a customer to be specified in every order.
+However, certain EPOS systems require a customer to be specified in every order.
 This section allows you to define the default first name, last name and email address that will be used for all your Deliveroo orders.
 
 ## Service Types
 
-This section allows you to specify the default ref codes used for all the service types.
+Service Type such as Delivery by Deliveroo, Delivery by your own fleed or Collection might require the corresponding ref code entry. Refer to your connected EPOS documentation on the HubRise website to verify.
 
 ## Delivery Charges
 
-This section allows you to specify the ref code associated with the delivery charge.
+If delivery charges apply, a ref code might be required. Refer to your connected EPOS documentation on the HubRise website to verify.
 
 ## Payment Methods
 
-Deliveroo customers can pay their order either online or by cash on delivery.
+Deliveroo customers can pay for their order either online or by cash on delivery.
 
 This section of the Configuration page allows you to specify the ref codes for these two payment methods, together with the payment type associated with online payments on the Deliveroo web site. Cash payments are always associated with the `cash` type.
 

--- a/content/apps/deliveroo/en/configuration.md
+++ b/content/apps/deliveroo/en/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Configuration Page
+title: Configuration
 position: 4
 layout: documentation
 meta:
@@ -46,4 +46,12 @@ Once you are happy with the configuration of the Deliveroo Bridge, click **Save*
 
 ## Resetting the Configuration
 
-You can always restore the configuration page to its default values and change the Deliveroo location ID associated with your HubRise location by clicking on **Reset the configuration** at the bottom of the page.
+If you want to reset the configuration and erase its values, click **Reset the configuration** at the bottom of the page.
+
+---
+
+**IMPORTANT NOTE:** Resetting the configuration will also erase your Deliveroo location ID. To continue receiving Deliveroo orders, you will need to enter your Deliveroo location ID again.
+
+---
+
+Resetting the configuration does not remove the operation logs displayed in the main page.

--- a/content/apps/deliveroo/en/configuration.md
+++ b/content/apps/deliveroo/en/configuration.md
@@ -3,8 +3,8 @@ title: Configuration Page
 position: 4
 layout: documentation
 meta:
-  title: Deliveroo Connection to HubRise Configuration
-  description: Instructions on how to configure Deliveroo Bridge.
+  title: Deliveroo Connection to HubRise - Configuration
+  description: See instructions to configure the Deliveroo Bridge to work seamlessly with Deliveroo and your EPOS or other apps connected to HubRise. Configuration is simple.
 ---
 
 The Configuration page allows you to customise the behaviour of the Deliveroo Bridge based on your preferences.


### PR DESCRIPTION
Please note that we changed the termonology. Point of Sales should always be referred to as EPOS (more modern) and not POS.

Regarding **Payment Methods**, I don't understand it.... 
It is the Deliveroo reference they need to input here? 
What about the EPOS ref code? Some of them need a reference.

Same for the **Discount** section. I guess the name and ref codes should be found in the EPOS, correct?

We need to include something along the lines of "Refer to your connected EPOS documentation on the HubRise website to verify" every time the user needs to check if an EPOS ref code is needed. This will at least explain to the reader that the reference can be fond in the EPOS.

FYI: The more Uber Eats connections I do, the more I think we will need a specific section for every EPOS documentation explaining how things are done. I will make a note of this in the iKento Board.