### PR TITLE
[Zelty] overview small fixes

### DIFF
--- a/content/apps/zelty/en/connect-hubrise.md
+++ b/content/apps/zelty/en/connect-hubrise.md
@@ -4,7 +4,7 @@ position: 2
 layout: documentation
 meta:
   title: Zelty - Connect to HubRise
-  description: 'Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.'
+  description: Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.
 ---
 
 The connection between Zelty and HubRise can be done autonomously by the user.

--- a/content/apps/zelty/en/faq.md
+++ b/content/apps/zelty/en/faq.md
@@ -4,7 +4,7 @@ position: 7
 layout: documentation
 meta:
   title: Zelty - HubRise FAQs
-  description: 'Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.'
+  description: Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.
 ---
 
 No frequently asked questions are available at this time.

--- a/content/apps/zelty/en/map-ref-codes.md
+++ b/content/apps/zelty/en/map-ref-codes.md
@@ -4,7 +4,7 @@ position: 3
 layout: documentation
 meta:
   title: Zelty - Mapping Ref Codes in HubRise
-  description: 'Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.'
+  description: Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.
 ---
 
 After connecting your Zelty EPOS to your HubRise account, you can sync information between them. For it to work however, certain steps need to be taken. Items in the Zelty EPOS are identified by unique codes. When you set up other apps to connect via HubRise, you need to provide these codes.

--- a/content/apps/zelty/en/orders.md
+++ b/content/apps/zelty/en/orders.md
@@ -4,7 +4,7 @@ position: 4
 layout: documentation
 meta:
   title: Zelty - Receive Orders from HubRise
-  description: 'Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.'
+  description: Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.
 ---
 
 Once HubRise is connected to Zelty and ref codes have been mapped, no further steps are needed. Your Zelty EPOS will automatically receive all orders sent to HubRise by other apps.

--- a/content/apps/zelty/en/overview.md
+++ b/content/apps/zelty/en/overview.md
@@ -4,7 +4,7 @@ title: Overview
 layout: documentation
 meta:
   title: Zelty - Overview & HubRise Integration
-  description: 'Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.'
+  description: Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.
 gallery:
   - 002-zelty-epos-interface.png
 
@@ -12,6 +12,7 @@ path_override: /
 app_info:
   category: Point of Sale
   availability: France
+  price_range: 
   website: https://zelty.fr
   contact: contact@zelty.fr / +33 9 72 53 55 72
 ---

--- a/content/apps/zelty/en/troubleshooting.md
+++ b/content/apps/zelty/en/troubleshooting.md
@@ -4,7 +4,7 @@ position: 5
 layout: documentation
 meta:
   title: Zelty - Troubleshooting Connection Issues
-  description: 'Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.'
+  description: Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.
 ---
 
 From time to time it may be necessary to troubleshoot certain issues with the connection between Zelty or HubRise. Should this need arise, the following information may be helpful.

--- a/content/apps/zelty/en/zelty-terms.md
+++ b/content/apps/zelty/en/zelty-terms.md
@@ -4,7 +4,7 @@ position: 6
 layout: documentation
 meta:
   title: Zelty - Terminology
-  description: 'Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.'
+  description: Connect Zelty to the apps you use everyday: food ordering platforms, mobile apps, ordering sites, marketing and loyalty solutions, delivery services, and more.
 ---
 
 Both HubRise and Zelty have their own vocabulary. Understanding the differences between the terms used can help resolve troubleshooting issues.


### PR DESCRIPTION
' symbol removed from Meta Tag descriptions
Inclusion of price_range: in overview.md. Even if we are not using it, I think we should keep it there (empty) 