### PR TITLE
Use "FAQs" instead of "Questions fréquentes"

### DIFF
--- a/content/apps/carre-pos/faqs/en/customization.yaml
+++ b/content/apps/carre-pos/faqs/en/customization.yaml
@@ -1,2 +1,2 @@
-name: F.A.Q.
+name: FAQ
 path_override: faqs

--- a/content/apps/carre-pos/faqs/fr/customization.yaml
+++ b/content/apps/carre-pos/faqs/fr/customization.yaml
@@ -1,2 +1,2 @@
-name: F.A.Q.
+name: FAQ
 path_override: faqs

--- a/content/apps/carre-pos/faqs/fr/prix-differents-produits.md
+++ b/content/apps/carre-pos/faqs/fr/prix-differents-produits.md
@@ -3,7 +3,7 @@ title: Comment Carré POS traite les différences de prix entre les produits ?
 position: 1
 layout: documentation
 meta:
-  title: Différences de prix entre les produits | Carré POS FAQ | HubRise
+  title: Différences de prix entre les produits | FAQs Carré POS | HubRise
   description: Comprendre comment est géré le cas des prix d'un produit différents entre Carré POS et une application web.
 ---
 

--- a/content/apps/carre-pos/faqs/fr/prix-differents-produits.md
+++ b/content/apps/carre-pos/faqs/fr/prix-differents-produits.md
@@ -3,7 +3,7 @@ title: Comment Carré POS traite les différences de prix entre les produits ?
 position: 1
 layout: documentation
 meta:
-  title: Différences de prix entre les produits | Carré POS F.A.Q. | HubRise
+  title: Différences de prix entre les produits | Carré POS FAQ | HubRise
   description: Comprendre comment est géré le cas des prix d'un produit différents entre Carré POS et une application web.
 ---
 

--- a/content/apps/carre-pos/fr/faqs.md
+++ b/content/apps/carre-pos/fr/faqs.md
@@ -1,9 +1,9 @@
 ---
-title: F.A.Q.
+title: FAQ
 position: 6
 layout: documentation
 meta:
-  title: F.A.Q. | Carré POS | HubRise
+  title: FAQ | Carré POS | HubRise
   description: Questions fréquentes posées sur la connexion de Carré POS à HubRise. Connectez vos applications à HubRise avec facilité et synchronisez vos données.
 ---
 

--- a/content/apps/just-eat-flyt/en/connect-hubrise.md
+++ b/content/apps/just-eat-flyt/en/connect-hubrise.md
@@ -22,7 +22,7 @@ As a first step, the HubRise Flyt API integration must be enabled on your Just E
 Contact us at [support@hubrise.com](mailto:support@hubrise.com) and include the following information in your email:
 
 - The URL link to your restaurant page on the Just Eat website. For example: [https://www.just-eat.ie/restaurants-saba-to-go-rathmines/](https://www.just-eat.ie/restaurants-saba-to-go-rathmines/).
-- Whether Auto-Accept should be `Activated` or `Deactivated`. For more details, see our [FAQ](/apps/just-eat-flyt/faqs/auto-accept).
+- Whether Auto-Accept should be `Activated` or `Deactivated`. For more details, see [Do I Want Auto-Accept Activated on Just Eat?](/apps/just-eat-flyt/faqs/auto-accept).
 - The email address of your Just Eat Account Manager.
 - Whether your Just Eat store is already connected to another middleware or EPOS.
 - Your HubRise location name and identifier. For example: `Fast Pizza Baker Street z6q31-0`.

--- a/content/apps/just-eat-flyt/faqs/fr/auto-acceptation.md
+++ b/content/apps/just-eat-flyt/faqs/fr/auto-acceptation.md
@@ -3,7 +3,7 @@ title: Dois-je activer l'auto-acceptation sur Just Eat ?
 position: 2
 layout: documentation
 meta:
-  title: Auto-accept | Questions fréquentes sur Just Eat Flyt | HubRise
+  title: Auto-accept | FAQs Just Eat Flyt | HubRise
   description: Cette page explique la fonction d'auto-acceptation de Just Eat lors de la connexion de HubRise à Just Eat Flyt Bridge.
 ---
 

--- a/content/apps/just-eat-flyt/faqs/fr/commandes-non-envoyees.md
+++ b/content/apps/just-eat-flyt/faqs/fr/commandes-non-envoyees.md
@@ -3,7 +3,7 @@ title: Pourquoi certains commandes ne sont-elles pas envoyés vers Just Eat ?
 position: 3
 layout: documentation
 meta:
-  title: Commandes non envoyés | Questions fréquentes Just Eat Flyt | HubRise
+  title: Commandes non envoyés | FAQs Just Eat Flyt | HubRise
   description: Si vos commandes Just Eat n'arrivent pas dans HubRise, cette page explique les raisons possibles et les solutions.
 ---
 

--- a/content/apps/just-eat-flyt/faqs/fr/customization.yaml
+++ b/content/apps/just-eat-flyt/faqs/fr/customization.yaml
@@ -1,2 +1,2 @@
-name: Questions Fréquentes
+name: FAQs
 path_override: faqs

--- a/content/apps/just-eat-flyt/faqs/fr/desactiver-tablette.md
+++ b/content/apps/just-eat-flyt/faqs/fr/desactiver-tablette.md
@@ -3,7 +3,7 @@ title: Puis-je désactiver la tablette ?
 position: 1
 layout: documentation
 meta:
- title: Tablette | Questions fréquentes sur Just Eat Flyt | HubRise
+ title: Tablette | FAQs Just Eat Flyt | HubRise
  description: Cette page explique pourquoi vous ne pouvez pas désactiver la tablette Just Eat lorsque vous connectez votre enseigne à HubRise avec Just Eat Flyt Bridge.
 ---
 

--- a/content/apps/just-eat-flyt/faqs/fr/produits-non-envoyes.md
+++ b/content/apps/just-eat-flyt/faqs/fr/produits-non-envoyes.md
@@ -3,7 +3,7 @@ title: Pourquoi certains produits ne sont-ils pas envoyés vers Just Eat ?
 position: 4
 layout: documentation
 meta:
- title: Produits non envoyés | Questions fréquentes Just Eat Flyt | HubRise
+ title: Produits non envoyés | FAQs Just Eat Flyt | HubRise
  description: Cette page explique pourquoi certains produits ne sont pas envoyés à Just Eat lorsque vous envoyez le catalogue sur la plateforme.
 ---
 

--- a/content/apps/just-eat-flyt/fr/connexion-hubrise.md
+++ b/content/apps/just-eat-flyt/fr/connexion-hubrise.md
@@ -22,7 +22,7 @@ Dans un premier temps, l'intégration de HubRise à l'API Flyt doit être activ�
 Contactez-nous par e-mail à l'adresse [support@hubrise.com](mailto:support@hubrise.com) en précisant les informations suivantes :
 
 - Le lien URL renvoyant à la page de votre restaurant sur le site internet de Just Eat. Exemple : [https://www.just-eat.fr/menu/asian-lover](https://www.just-eat.fr/menu/asian-lover).
-- Indiquez si l'acceptation automatique doit être `activée` ou `désactivée`. Pour plus de détails, consultez nos [Questions fréquentes](/apps/just-eat-flyt/faqs/auto-acceptation).
+- Indiquez si l'acceptation automatique doit être `activée` ou `désactivée`. Pour plus de détails, consultez [Dois-je activer l'auto-acceptation sur Just Eat ?](/apps/just-eat-flyt/faqs/auto-acceptation).
 - L'adresse e-mail de votre responsable de compte Just Eat.
 - Indiquez si votre enseigne sur le site internet de Just Eat est déjà connectée à une caisse ou un autre middleware.
 - Le nom et l'identifiant de votre point de vente HubRise. Exemple : `Sushi Shop Colbert z6q31-0`.

--- a/content/apps/just-eat-flyt/fr/faqs.md
+++ b/content/apps/just-eat-flyt/fr/faqs.md
@@ -1,9 +1,9 @@
 ---
-title: Questions fréquentes
+title: FAQs
 position: 8
 layout: documentation
 meta:
-  title: Questions fréquentes | Just Eat Flyt | HubRise
+  title: FAQs | Just Eat Flyt | HubRise
   description: Questions fréquentes sur la connexion de Just Eat Flyt à HubRise afin que votre logiciel de caisse fonctionne avec d'autres applications comme un tout cohérent.
 ---
 

--- a/content/apps/kezia/faqs/fr/customization.yaml
+++ b/content/apps/kezia/faqs/fr/customization.yaml
@@ -1,2 +1,2 @@
-name: F.A.Q.
+name: FAQ
 path_override: faqs

--- a/content/apps/kezia/faqs/fr/differences-prix.md
+++ b/content/apps/kezia/faqs/fr/differences-prix.md
@@ -3,7 +3,7 @@ title: Comment Kezia II traite les différences de prix ?
 position: 2
 layout: documentation
 meta:
-  title: Différences de prix | Kezia II F.A.Q. | HubRise
+  title: Différences de prix | Kezia II FAQ | HubRise
   description: Comment Kezia II traite les différences de prix dans les commandes venant de HubRise.
 ---
 

--- a/content/apps/kezia/faqs/fr/differences-prix.md
+++ b/content/apps/kezia/faqs/fr/differences-prix.md
@@ -3,7 +3,7 @@ title: Comment Kezia II traite les différences de prix ?
 position: 2
 layout: documentation
 meta:
-  title: Différences de prix | Kezia II FAQ | HubRise
+  title: Différences de prix | FAQs Kezia II | HubRise
   description: Comment Kezia II traite les différences de prix dans les commandes venant de HubRise.
 ---
 

--- a/content/apps/kezia/faqs/fr/produit-non-exporte.md
+++ b/content/apps/kezia/faqs/fr/produit-non-exporte.md
@@ -3,7 +3,7 @@ title: Je viens de créer un produit dans Kezia II. Pourquoi n'apparaît-il pas 
 position: 1
 layout: documentation
 meta:
-  title: Produit non exporté | Kezia II FAQ | HubRise
+  title: Produit non exporté | FAQs Kezia II | HubRise
   description: Comment activer l'export d'un produit vers HubRise dans Kezia II.
 ---
 

--- a/content/apps/kezia/faqs/fr/produit-non-exporte.md
+++ b/content/apps/kezia/faqs/fr/produit-non-exporte.md
@@ -3,7 +3,7 @@ title: Je viens de créer un produit dans Kezia II. Pourquoi n'apparaît-il pas 
 position: 1
 layout: documentation
 meta:
-  title: Produit non exporté | Kezia II F.A.Q. | HubRise
+  title: Produit non exporté | Kezia II FAQ | HubRise
   description: Comment activer l'export d'un produit vers HubRise dans Kezia II.
 ---
 

--- a/content/apps/kezia/fr/faqs.md
+++ b/content/apps/kezia/fr/faqs.md
@@ -1,9 +1,9 @@
 ---
-title: F.A.Q.
+title: FAQ
 position: 7
 layout: documentation
 meta:
-  title: F.A.Q. | Kezia II | HubRise
+  title: FAQ | Kezia II | HubRise
   description: Questions fréquentes posées sur la connexion de Kezia II à HubRise. Connectez vos applications à HubRise avec facilité et synchronisez vos données.
 ---
 

--- a/content/apps/leo2/faqs/fr/commandes-non-recues.md
+++ b/content/apps/leo2/faqs/fr/commandes-non-recues.md
@@ -3,7 +3,7 @@ title: Les commandes HubRise n'arrivent pas dans LEO2. Que faire ?
 position: 1
 layout: documentation
 meta:
-  title: Commandes HubRise non reçues | LEO2 F.A.Q. | HubRise
+  title: Commandes HubRise non reçues | LEO2 FAQ | HubRise
   description: Que faire lorsque les commandes HubRise n'arrivent pas dans LEO2 ?
 ---
 

--- a/content/apps/leo2/faqs/fr/commandes-non-recues.md
+++ b/content/apps/leo2/faqs/fr/commandes-non-recues.md
@@ -3,7 +3,7 @@ title: Les commandes HubRise n'arrivent pas dans LEO2. Que faire ?
 position: 1
 layout: documentation
 meta:
-  title: Commandes HubRise non reçues | LEO2 FAQ | HubRise
+  title: Commandes HubRise non reçues | FAQs LEO2 | HubRise
   description: Que faire lorsque les commandes HubRise n'arrivent pas dans LEO2 ?
 ---
 

--- a/content/apps/leo2/faqs/fr/customization.yaml
+++ b/content/apps/leo2/faqs/fr/customization.yaml
@@ -1,2 +1,2 @@
-name: F.A.Q.
+name: FAQ
 path_override: faqs

--- a/content/apps/leo2/fr/faqs.md
+++ b/content/apps/leo2/fr/faqs.md
@@ -1,9 +1,9 @@
 ---
-title: F.A.Q.
+title: FAQ
 position: 9
 layout: documentation
 meta:
-  title: F.A.Q. | LEO2 | HubRise
+  title: FAQ | LEO2 | HubRise
   description: Questions fréquentes posées sur la connexion de LEO2 à HubRise. Connectez vos applications à HubRise avec facilité et synchronisez vos données.
 ---
 

--- a/content/apps/leo2/fr/recevoir-commandes.md
+++ b/content/apps/leo2/fr/recevoir-commandes.md
@@ -9,7 +9,7 @@ meta:
 
 Lorsque LEO2 est connecté à HubRise, les commandes envoyées à HubRise arrivent automatiquement dans votre logiciel de caisse.
 
-LEO2 vérifie l'arrivée de nouvelles commandes toutes les 30 secondes. Si vous ne recevez aucune commande, consultez la F.A.Q. [Les commandes HubRise n'arrivent pas dans LEO2. Que faire ?](/apps/leo2/faqs/commandes-non-recues).
+LEO2 vérifie l'arrivée de nouvelles commandes toutes les 30 secondes. Si vous ne recevez aucune commande, consultez la FAQ [Les commandes HubRise n'arrivent pas dans LEO2. Que faire ?](/apps/leo2/faqs/commandes-non-recues).
 
 ## Interface utilisateur
 

--- a/content/apps/leo2/fr/recevoir-commandes.md
+++ b/content/apps/leo2/fr/recevoir-commandes.md
@@ -9,7 +9,7 @@ meta:
 
 Lorsque LEO2 est connecté à HubRise, les commandes envoyées à HubRise arrivent automatiquement dans votre logiciel de caisse.
 
-LEO2 vérifie l'arrivée de nouvelles commandes toutes les 30 secondes. Si vous ne recevez aucune commande, consultez la FAQ [Les commandes HubRise n'arrivent pas dans LEO2. Que faire ?](/apps/leo2/faqs/commandes-non-recues).
+LEO2 vérifie l'arrivée de nouvelles commandes toutes les 30 secondes. Si vous ne recevez aucune commande, consultez [Les commandes HubRise n'arrivent pas dans LEO2. Que faire ?](/apps/leo2/faqs/commandes-non-recues).
 
 ## Interface utilisateur
 

--- a/content/apps/lightspeed-restaurant/faqs/fr/customization.yaml
+++ b/content/apps/lightspeed-restaurant/faqs/fr/customization.yaml
@@ -1,2 +1,2 @@
-name: F.A.Q.
+name: FAQ
 path_override: faqs

--- a/content/apps/lightspeed-restaurant/fr/faqs.md
+++ b/content/apps/lightspeed-restaurant/fr/faqs.md
@@ -1,9 +1,9 @@
 ---
-title: F.A.Q.
+title: FAQ
 position: 6
 layout: documentation
 meta:
-  title: F.A.Q. | Lightspeed Restaurant | HubRise
+  title: FAQ | Lightspeed Restaurant | HubRise
   description: Questions fréquentes posées sur la connexion de Lightspeed Restaurant à HubRise. Connectez vos applications à HubRise avec facilité et synchronisez vos données.
 ---
 

--- a/content/apps/nestor/faqs/en/customization.yaml
+++ b/content/apps/nestor/faqs/en/customization.yaml
@@ -1,2 +1,2 @@
-name: F.A.Q.
+name: FAQ
 path_override: faqs

--- a/content/apps/nestor/faqs/fr/commandes-non-recues.md
+++ b/content/apps/nestor/faqs/fr/commandes-non-recues.md
@@ -3,7 +3,7 @@ title: Les commandes HubRise n'arrivent pas dans Nestor, que faire ?
 position: 3
 layout: documentation
 meta:
-  title: Commandes HubRise non reçues | Nestor FAQ | HubRise
+  title: Commandes HubRise non reçues | FAQs Nestor | HubRise
   description: Que faire lorsque les commandes HubRise n'arrivent pas dans Nestor.
 ---
 

--- a/content/apps/nestor/faqs/fr/commandes-non-recues.md
+++ b/content/apps/nestor/faqs/fr/commandes-non-recues.md
@@ -3,7 +3,7 @@ title: Les commandes HubRise n'arrivent pas dans Nestor, que faire ?
 position: 3
 layout: documentation
 meta:
-  title: Commandes HubRise non reçues | Nestor F.A.Q. | HubRise
+  title: Commandes HubRise non reçues | Nestor FAQ | HubRise
   description: Que faire lorsque les commandes HubRise n'arrivent pas dans Nestor.
 ---
 

--- a/content/apps/nestor/faqs/fr/customization.yaml
+++ b/content/apps/nestor/faqs/fr/customization.yaml
@@ -1,2 +1,2 @@
-name: F.A.Q.
+name: FAQ
 path_override: faqs

--- a/content/apps/nestor/faqs/fr/prix-differents-articles.md
+++ b/content/apps/nestor/faqs/fr/prix-differents-articles.md
@@ -3,7 +3,7 @@ title: Comment Nestor traite les différences de prix dans les articles ?
 position: 1
 layout: documentation
 meta:
-  title: Différences de prix dans les articles | Nestor FAQ | HubRise
+  title: Différences de prix dans les articles | FAQs Nestor | HubRise
   description: Comprendre comment Nestor traite les différences de prix dans les commandes HubRise.
 ---
 

--- a/content/apps/nestor/faqs/fr/prix-differents-articles.md
+++ b/content/apps/nestor/faqs/fr/prix-differents-articles.md
@@ -3,7 +3,7 @@ title: Comment Nestor traite les différences de prix dans les articles ?
 position: 1
 layout: documentation
 meta:
-  title: Différences de prix dans les articles | Nestor F.A.Q. | HubRise
+  title: Différences de prix dans les articles | Nestor FAQ | HubRise
   description: Comprendre comment Nestor traite les différences de prix dans les commandes HubRise.
 ---
 

--- a/content/apps/nestor/faqs/fr/produit-introuvable-hubrise.md
+++ b/content/apps/nestor/faqs/fr/produit-introuvable-hubrise.md
@@ -3,7 +3,7 @@ title: Je viens de créer un produit dans Nestor, pourquoi n'apparaît-il pas da
 position: 3
 layout: documentation
 meta:
-  title: Exporter un produit | Nestor FAQ | HubRise
+  title: Exporter un produit | FAQs Nestor | HubRise
   description: Comment exporter un produit créé dans Nestor vers mon catalogue HubRise.
 ---
 

--- a/content/apps/nestor/faqs/fr/produit-introuvable-hubrise.md
+++ b/content/apps/nestor/faqs/fr/produit-introuvable-hubrise.md
@@ -3,7 +3,7 @@ title: Je viens de créer un produit dans Nestor, pourquoi n'apparaît-il pas da
 position: 3
 layout: documentation
 meta:
-  title: Exporter un produit | Nestor F.A.Q. | HubRise
+  title: Exporter un produit | Nestor FAQ | HubRise
   description: Comment exporter un produit créé dans Nestor vers mon catalogue HubRise.
 ---
 

--- a/content/apps/nestor/faqs/fr/synchroniser-points-vente.md
+++ b/content/apps/nestor/faqs/fr/synchroniser-points-vente.md
@@ -3,7 +3,7 @@ title: J'ai plusieurs points de vente utilisant Nestor avec le même menu, dois-
 position: 2
 layout: documentation
 meta:
-  title: Synchronisation menu commun | Nestor FAQ | HubRise
+  title: Synchronisation menu commun | FAQs Nestor | HubRise
   description: Comment synchroniser un menu utilisé dans plusieurs points de vente Nestor avec HubRise.
 ---
 

--- a/content/apps/nestor/faqs/fr/synchroniser-points-vente.md
+++ b/content/apps/nestor/faqs/fr/synchroniser-points-vente.md
@@ -3,7 +3,7 @@ title: J'ai plusieurs points de vente utilisant Nestor avec le même menu, dois-
 position: 2
 layout: documentation
 meta:
-  title: Synchronisation menu commun | Nestor F.A.Q. | HubRise
+  title: Synchronisation menu commun | Nestor FAQ | HubRise
   description: Comment synchroniser un menu utilisé dans plusieurs points de vente Nestor avec HubRise.
 ---
 

--- a/content/apps/nestor/faqs/fr/validation-commande-impossible.md
+++ b/content/apps/nestor/faqs/fr/validation-commande-impossible.md
@@ -3,7 +3,7 @@ title: Pourquoi ne puis-je pas valider une commande web dans Nestor ?
 position: 4
 layout: documentation
 meta:
-  title: Valider une commande | Nestor F.A.Q. | HubRise
+  title: Valider une commande | Nestor FAQ | HubRise
   description: Comprendre pourquoi il est impossible de valider une commande web dans Nestor.
 ---
 

--- a/content/apps/nestor/faqs/fr/validation-commande-impossible.md
+++ b/content/apps/nestor/faqs/fr/validation-commande-impossible.md
@@ -3,7 +3,7 @@ title: Pourquoi ne puis-je pas valider une commande web dans Nestor ?
 position: 4
 layout: documentation
 meta:
-  title: Valider une commande | Nestor FAQ | HubRise
+  title: Valider une commande | FAQs Nestor | HubRise
   description: Comprendre pourquoi il est impossible de valider une commande web dans Nestor.
 ---
 

--- a/content/apps/nestor/fr/faqs.md
+++ b/content/apps/nestor/fr/faqs.md
@@ -1,9 +1,9 @@
 ---
-title: F.A.Q.
+title: FAQ
 position: 7
 layout: documentation
 meta:
-  title: F.A.Q. | Nestor | HubRise
+  title: FAQ | Nestor | HubRise
   description: Questions fréquentes posées sur la connexion de Nestor à HubRise. Connectez vos applications à HubRise avec facilité et synchronisez vos données.
 ---
 

--- a/content/contributing/en/style-guide.md
+++ b/content/contributing/en/style-guide.md
@@ -365,7 +365,7 @@ The content should be relevant and unique from other pages. It should be easy to
 > - **Map Ref Codes**: Instructions on mapping Lightspeed K Series product ref codes with other apps after connecting your EPOS with HubRise. Connect apps and synchronise your data.
 > - **Troubleshooting**: Troubleshooting Lightspeed K Series connection with HubRise for your EPOS and other apps to work as a cohesive whole. Connect apps and synchronise your data.
 > - **Terminology**: Correspondence table showing terms used by Lightspeed K Series and those used on HubRise for the same concept. Connect apps and synchronise your data.
-> - **FAQ**: FAQs on connecting Lightspeed K Series with HubRise for your EPOS to work with other apps as a cohesive whole. Connect apps and synchronise your data.
+> - **FAQs**: FAQs on connecting Lightspeed K Series with HubRise for your EPOS to work with other apps as a cohesive whole. Connect apps and synchronise your data.
 
 To complete a meta description and maximise the number of characters, it is possible to add a small sentence at the end:
 

--- a/content/contributing/fr/guide-de-style.md
+++ b/content/contributing/fr/guide-de-style.md
@@ -208,7 +208,7 @@ Le contenu doit être pertinent et unique par rapport aux autres pages. Il doit 
 > - **Associer les codes ref** : Instructions pour associer les codes ref des produits Lightspeed K Series avec d'autres applications connectées à HubRise pour la synchronisation des données.
 > - **Dépannage** : Dépannage de la connexion entre Lightspeed K Series et HubRise. Connectez votre caisse et synchronisez les données entre vos applications avec facilité.
 > - **Terminologie** : Table de correspondance entre les termes utilisés par Lightspeed K Series et HubRise pour le même concept. Connectez vos apps et synchronisez vos données.
-> - **F.A.Q.** : Questions fréquentes posées sur la connexion de Lightspeed K Series à HubRise. Connectez vos applications à HubRise avec facilité et synchronisez vos données.
+> - **FAQs** : Questions fréquentes posées sur la connexion de Lightspeed K Series à HubRise. Connectez vos applications à HubRise avec facilité et synchronisez vos données.
 
 Pour compléter une méta-description en maximisant le nombre de caractères, vous pouvez ajouter une courte phrase à la fin :
 

--- a/content/docs/faqs/fr/customization.yaml
+++ b/content/docs/faqs/fr/customization.yaml
@@ -1,2 +1,2 @@
-name:  F.A.Q.
+name:  FAQ
 path_override: faqs

--- a/content/docs/fr/comment-demarrer.md
+++ b/content/docs/fr/comment-demarrer.md
@@ -15,7 +15,7 @@ Pour commencer à utiliser HubRise, vous devez créer un profil utilisateur. L'i
 
 ---
 
-**FAQs associées** : Comment créer un profil utilisateur pour [quelqu'un d'autre](/docs/faqs/creer-profil-utilisateur-pour-une-autre-personne/) ou pour une [autre entreprise ?](/docs/faqs/creer-compte-pour-une-autre-entreprise/)
+**FAQ associée** : Comment créer un profil utilisateur pour [quelqu'un d'autre](/docs/faqs/creer-profil-utilisateur-pour-une-autre-personne/) ou pour une [autre entreprise ?](/docs/faqs/creer-compte-pour-une-autre-entreprise/)
 
 ---
 
@@ -69,7 +69,7 @@ Pour vous connecter à HubRise, consultez la [page de connexion à HubRise](http
 
 ---
 
-**FAQs associées** : [Comment vérifier si j'ai déjà un profil d'utilisateur dans HubRise ?](/docs/faqs/verifier-si-j-ai-deja-un-profil-utilisateur-dans-hubrise/)
+**FAQ associée** : [Comment vérifier si j'ai déjà un profil d'utilisateur dans HubRise ?](/docs/faqs/verifier-si-j-ai-deja-un-profil-utilisateur-dans-hubrise/)
 
 ---
 

--- a/content/docs/fr/comment-demarrer.md
+++ b/content/docs/fr/comment-demarrer.md
@@ -15,7 +15,7 @@ Pour commencer à utiliser HubRise, vous devez créer un profil utilisateur. L'i
 
 ---
 
-**Questions fréquentes associées** : Comment créer un profil utilisateur pour [quelqu'un d'autre](/docs/faqs/creer-profil-utilisateur-pour-une-autre-personne/) ou pour une [autre entreprise ?](/docs/faqs/creer-compte-pour-une-autre-entreprise/)
+**FAQs associées** : Comment créer un profil utilisateur pour [quelqu'un d'autre](/docs/faqs/creer-profil-utilisateur-pour-une-autre-personne/) ou pour une [autre entreprise ?](/docs/faqs/creer-compte-pour-une-autre-entreprise/)
 
 ---
 
@@ -69,7 +69,7 @@ Pour vous connecter à HubRise, consultez la [page de connexion à HubRise](http
 
 ---
 
-**Questions fréquentes associées** : [Comment vérifier si j'ai déjà un profil d'utilisateur dans HubRise ?](/docs/faqs/verifier-si-j-ai-deja-un-profil-utilisateur-dans-hubrise/)
+**FAQs associées** : [Comment vérifier si j'ai déjà un profil d'utilisateur dans HubRise ?](/docs/faqs/verifier-si-j-ai-deja-un-profil-utilisateur-dans-hubrise/)
 
 ---
 

--- a/content/docs/fr/comptes.md
+++ b/content/docs/fr/comptes.md
@@ -52,7 +52,7 @@ Enfin, saisissez la **devise** correcte du marché sur lequel vous opérez.
 
 ---
 
-**Questions fréquentes associées** : [J'ai trop de comptes pour mon entreprise sur HubRise. Comment faire un nettoyage ?](/docs/faqs/comment-effacer-des-comptes/)
+**FAQs associées** : [J'ai trop de comptes pour mon entreprise sur HubRise. Comment faire un nettoyage ?](/docs/faqs/comment-effacer-des-comptes/)
 
 ---
 

--- a/content/docs/fr/comptes.md
+++ b/content/docs/fr/comptes.md
@@ -52,7 +52,7 @@ Enfin, saisissez la **devise** correcte du marché sur lequel vous opérez.
 
 ---
 
-**FAQs associées** : [J'ai trop de comptes pour mon entreprise sur HubRise. Comment faire un nettoyage ?](/docs/faqs/comment-effacer-des-comptes/)
+**FAQ associée** : [J'ai trop de comptes pour mon entreprise sur HubRise. Comment faire un nettoyage ?](/docs/faqs/comment-effacer-des-comptes/)
 
 ---
 

--- a/content/docs/fr/connexions.md
+++ b/content/docs/fr/connexions.md
@@ -52,7 +52,7 @@ Pour afficher un graphique montrant le nombre de transactions enregistrées au c
 
 ---
 
-**FAQs associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
+**FAQ associée** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
 
 ---
 
@@ -103,7 +103,7 @@ Pour plus d'informations, voir la rubrique [Comprendre les logs HubRise](/docs/h
 
 ---
 
-**FAQs associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
+**FAQ associée** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
 
 ---
 

--- a/content/docs/fr/connexions.md
+++ b/content/docs/fr/connexions.md
@@ -52,7 +52,7 @@ Pour afficher un graphique montrant le nombre de transactions enregistrées au c
 
 ---
 
-**Questions fréquentes associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
+**FAQs associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
 
 ---
 
@@ -103,7 +103,7 @@ Pour plus d'informations, voir la rubrique [Comprendre les logs HubRise](/docs/h
 
 ---
 
-**Questions fréquentes associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
+**FAQs associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
 
 ---
 

--- a/content/docs/fr/donnees.md
+++ b/content/docs/fr/donnees.md
@@ -30,7 +30,7 @@ Cliquez sur la date de la commande pour afficher les détails complets. Pour aff
 
 ---
 
-**FAQs associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
+**FAQ associée** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
 
 ---
 

--- a/content/docs/fr/donnees.md
+++ b/content/docs/fr/donnees.md
@@ -30,7 +30,7 @@ Cliquez sur la date de la commande pour afficher les détails complets. Pour aff
 
 ---
 
-**Questions fréquentes associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
+**FAQs associées** : [Comment vérifier que la connexion entre mon système et HubRise fonctionne correctement ?](/docs/faqs/verifier-connexion-entre-mon-systeme-et-hubrise/)
 
 ---
 

--- a/content/docs/fr/paiement.md
+++ b/content/docs/fr/paiement.md
@@ -91,7 +91,7 @@ Pour supprimer une méthode de paiement, procédez comme suit :
 
 ---
 
-**FAQs associées** : [Comment cesser le paiement de mon abonnement ?](/docs/faqs/arreter-de-payer-abonnement/)
+**FAQ associée** : [Comment cesser le paiement de mon abonnement ?](/docs/faqs/arreter-de-payer-abonnement/)
 
 ---
 
@@ -107,7 +107,7 @@ Pour traiter un paiement à partir de la notification, procédez comme suit :
 
 ---
 
-**FAQs associées** : [Que se passe-t-il en cas de dépassement de quota de ma formule gratuite ?](/docs/faqs/formule-gratuite-quota-depasse-ce-qui-se-passe/), [Comment payer ma première facture ?](/docs/faqs/payer-la-premiere-facture/), [Ma formule peut-elle être interrompue durant les phases de configuration et de test ?](/docs/faqs/formule-interrompue-pendant-les-phases-de-configuration-et-de-test/)
+**FAQ associée** : [Que se passe-t-il en cas de dépassement de quota de ma formule gratuite ?](/docs/faqs/formule-gratuite-quota-depasse-ce-qui-se-passe/), [Comment payer ma première facture ?](/docs/faqs/payer-la-premiere-facture/), [Ma formule peut-elle être interrompue durant les phases de configuration et de test ?](/docs/faqs/formule-interrompue-pendant-les-phases-de-configuration-et-de-test/)
 
 ---
 

--- a/content/docs/fr/paiement.md
+++ b/content/docs/fr/paiement.md
@@ -91,7 +91,7 @@ Pour supprimer une méthode de paiement, procédez comme suit :
 
 ---
 
-**Questions fréquentes associées** : [Comment cesser le paiement de mon abonnement ?](/docs/faqs/arreter-de-payer-abonnement/)
+**FAQs associées** : [Comment cesser le paiement de mon abonnement ?](/docs/faqs/arreter-de-payer-abonnement/)
 
 ---
 
@@ -107,7 +107,7 @@ Pour traiter un paiement à partir de la notification, procédez comme suit :
 
 ---
 
-**Questions fréquentes associées** : [Que se passe-t-il en cas de dépassement de quota de ma formule gratuite ?](/docs/faqs/formule-gratuite-quota-depasse-ce-qui-se-passe/), [Comment payer ma première facture ?](/docs/faqs/payer-la-premiere-facture/), [Ma formule peut-elle être interrompue durant les phases de configuration et de test ?](/docs/faqs/formule-interrompue-pendant-les-phases-de-configuration-et-de-test/)
+**FAQs associées** : [Que se passe-t-il en cas de dépassement de quota de ma formule gratuite ?](/docs/faqs/formule-gratuite-quota-depasse-ce-qui-se-passe/), [Comment payer ma première facture ?](/docs/faqs/payer-la-premiere-facture/), [Ma formule peut-elle être interrompue durant les phases de configuration et de test ?](/docs/faqs/formule-interrompue-pendant-les-phases-de-configuration-et-de-test/)
 
 ---
 

--- a/content/fr/faqs.md
+++ b/content/fr/faqs.md
@@ -1,8 +1,8 @@
 ---
-title: F.A.Q
+title: FAQs
 layout: documentation-simple
 meta:
-  title: F.A.Q. | HubRise
+  title: FAQs | HubRise
   description:
 ---
 

--- a/content/fr/menu-header.yaml
+++ b/content/fr/menu-header.yaml
@@ -9,5 +9,5 @@
   to: /fr/developers
 - title: Aide
   to: /fr/docs
-- title: F.A.Q.
-  to: /fr/faq
+- title: FAQs
+  to: /fr/faqs

--- a/content/fr/pricing.yaml
+++ b/content/fr/pricing.yaml
@@ -28,6 +28,3 @@ content:
     - highlight: "Dark kitchen :"
       text: Des frais additionnels peuvent s'appliquer.
       button: Nous contacter
-  faq:
-    text: Voir notre F.A.Q. concernant l'abonnement
-    to: /faq#abonnement

--- a/content/redirects.yaml
+++ b/content/redirects.yaml
@@ -1,3 +1,7 @@
+# Main pages
+- fromPath: /fr/faq
+  toPath: /fr/faqs
+
 # Developers
 - fromPath: /developers/api
   toPath: /developers/api/general-concepts


### PR DESCRIPTION
@janaina-wittner I've changed my mind, because it seemed strange to translate an acronym in EN ("FAQ") by two words in FR ("Questions fréquentes"). The French dictionary Robert has an [entry for FAQ](https://dictionnaire.lerobert.com/definition/faq) so I guess this is fine.

Also, our common practice so far has been to write FAQ without dots. I've replaced "F.A.Q." by "FAQ" in the few places where the former was used.

So in short, we will use "FAQ" in both French and English, not "F.A.Q." / "Questions Fréquentes". I've created entries for valid & forbidden terms in XTM terminology.