### PR TITLE
[TakeAway] T-Connect not compatible with HubRise

### DIFF
--- a/content/apps/just-eat-takeaway/en/overview.md
+++ b/content/apps/just-eat-takeaway/en/overview.md
@@ -49,11 +49,7 @@ Connecting Just Eat Takeaway Bridge allows HubRise to:
 
 ![Diagram of the connection flow between Just Eat Takeaway, Just Eat Takeaway Bridge, and HubRise](../images/000-en-2x-jet-connection-diagram.png)
 
----
-
-**IMPORTANT NOTE:** The Just Eat OrderPad will need to remain switched on to receive orders in HubRise.
-
----
+Just Eat Takeaway Bridge works as standalone: when you activate it, orders are no longer sent to T-Connect.
 
 Just Eat Takeaway Bridge can be connected to HubRise from the HubRise back office.
 

--- a/content/apps/just-eat-takeaway/en/terminology.md
+++ b/content/apps/just-eat-takeaway/en/terminology.md
@@ -11,7 +11,7 @@ meta:
 
 The following table explains the terms that are specific to Just Eat Takeaway.
 
-| Term      | Description                                                  |
-| --------- | ------------------------------------------------------------ |
-| T-Connect | A portable device with a built-in printer to receive orders. |
-| Orderpad  | Just Eat's official app to manage incoming orders.           |
+| Term        | Description                                                  |
+| ----------- |--------------------------------------------------------------|
+| T-Connect   | A portable device with a built-in printer to receive orders. |
+| Live Orders | Just Eat's web app, used as a backup to receive orders.      |

--- a/content/apps/just-eat-takeaway/fr/presentation-generale.md
+++ b/content/apps/just-eat-takeaway/fr/presentation-generale.md
@@ -49,11 +49,7 @@ La connexion de Just Eat Takeaway Bridge permet à HubRise de :
 
 ![Schéma du flux de connexion entre Just Eat Takeaway, Just Eat Takeaway Bridge et HubRise](../images/000-fr-2x-jet-connection-diagram.png)
 
----
-
-**REMARQUE IMPORTANTE** : la tablette Just Eat doit rester allumée pour recevoir les commandes dans HubRise.
-
----
+Just Eat Takeaway Bridge fonctionne de manière autonome : lorsque vous l'activez, les commandes ne sont plus transmises à T-Connect.
 
 Just Eat Takeaway Bridge peut être connecté à HubRise depuis le back-office de HubRise.
 

--- a/content/apps/just-eat-takeaway/fr/terminologie.md
+++ b/content/apps/just-eat-takeaway/fr/terminologie.md
@@ -11,7 +11,7 @@ meta:
 
 Le tableau suivant explique les termes spécifiques à Just Eat Takeaway.
 
-| Terme      | Description                                                  |
-| --------- | ------------------------------------------------------------ |
-| T-Connect | Dispositif portable doté d'une imprimante intégrée permettant de recevoir les commandes.   |
-| Orderpad  | Application officielle de Just Eat qui permet de gérer les commandes entrantes.           |
+| Terme       | Description                                                                              |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| T-Connect   | Dispositif portable doté d'une imprimante intégrée permettant de recevoir les commandes. |
+| Live Orders | Application Web de Just Eat, utilisée en secours pour recevoir les commandes.            |


### PR DESCRIPTION
[This FAQ](https://www.hubrise.com/apps/just-eat-takeaway/faqs/primary-secondary-connections/) must also be rewritten, when we have a final confirmation that T-Connect & HubRise cannot work in parallel.

Let's hold on until we have the call with Just Eat next week to clarify our understanding of the workflow.

cc @janaina-wittner 
